### PR TITLE
Configured platformio build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+.*/

--- a/README.md
+++ b/README.md
@@ -24,15 +24,18 @@ high-speed either.
 
 ## Building
 
-1. Install [esp-open-sdk](https://github.com/pfalcon/esp-open-sdk)
-1. `sudo apt install esptool`
-1. Compile and flash
+- Use [Platformio](https://docs.platformio.org/en/stable/integration/ide/vscode.html) to easily build and flash ESP8266 from the VScode.
 
-```
-ESP_OPEN_SDK=/opt/esp-open-sdk
-export XTENSA_TOOLS_ROOT=$ESP_OPEN_SDK/xtensa-lx106-elf/bin SDK_BASE=$ESP_OPEN_SDK/sdk flash
-make flash
-```
+- Alternatively,
+  1. Install [esp-open-sdk](https://github.com/pfalcon/esp-open-sdk)
+  1. `sudo apt install esptool`
+  1. Compile and flash:
+
+  ```
+  ESP_OPEN_SDK=/opt/esp-open-sdk
+  export XTENSA_TOOLS_ROOT=$ESP_OPEN_SDK/xtensa-lx106-elf/bin SDK_BASE=$ESP_OPEN_SDK/sdk flash
+  make flash
+  ```
 
 ### Using a precompiled binary
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,16 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp-stlink]
+platform = espressif8266
+board = d1_mini
+framework = esp8266-nonos-sdk
+build_flags = -I src/include
+monitor_speed = 921600

--- a/src/user/user_main.c
+++ b/src/user/user_main.c
@@ -11,13 +11,53 @@
  * You should have received a copy of the GNU General Public License along
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+#include "user_interface.h"
+
 #include "driver/swim.h"
 #include "driver/uart.h"
 #include "serial.h"
 
+uint32 ICACHE_FLASH_ATTR
+user_rf_cal_sector_set(void) {
+    enum flash_size_map size_map = system_get_flash_size_map();
+    uint32 rf_cal_sec = 0;
+
+    switch (size_map) {
+        case FLASH_SIZE_4M_MAP_256_256:
+            rf_cal_sec = 128 - 5;
+            break;
+
+        case FLASH_SIZE_8M_MAP_512_512:
+            rf_cal_sec = 256 - 5;
+            break;
+
+        case FLASH_SIZE_16M_MAP_512_512:
+        case FLASH_SIZE_16M_MAP_1024_1024:
+            rf_cal_sec = 512 - 5;
+            break;
+
+        case FLASH_SIZE_32M_MAP_512_512:
+        case FLASH_SIZE_32M_MAP_1024_1024:
+            rf_cal_sec = 1024 - 5;
+            break;
+
+        case FLASH_SIZE_64M_MAP_1024_1024:
+            rf_cal_sec = 2048 - 5;
+            break;
+        case FLASH_SIZE_128M_MAP_1024_1024:
+            rf_cal_sec = 4096 - 5;
+            break;
+        default:
+            rf_cal_sec = 0;
+            break;
+    }
+    return rf_cal_sec;
+}
+
 void user_init(void) {
   swim_init();
   uart_init(BIT_RATE_921600, BIT_RATE_921600);
-  uart0_sendStr("ESP-STLINK\r\n");
+  uart0_sendStr("\r\nESP-STLINK\r\n");
   serial_init();
 }


### PR DESCRIPTION
Simple platformio configuration. 

`user_rf_cal_sector_set` function added as required by the linker. This is probably because Platformio uses [older SDK](https://github.com/platformio/platform-espressif8266/pull/284).  It's a default function provided from espressif [example](https://github.com/espressif/ESP8266_NONOS_SDK/commit/5b0c60108b8ca2719210436c6e808e131676fc3a#diff-e1d075ca3c6cdee0e153e9de6123982610153a08f2a369dc051b1bd096e4ac67L123-L160)

It firmware compiles,flashes, and communicates over UART but I have not yet tested with stm8.

Resolves https://github.com/rumpeltux/esp-stlink/issues/16.